### PR TITLE
Use attachEvent instead of addEventListener when addEventListener is not present

### DIFF
--- a/src/local.js
+++ b/src/local.js
@@ -134,7 +134,7 @@ function sessionListener(e) {
 if (global.addEventListener) {
 	global.addEventListener('storage', sessionListener);
 } else if (global.attachEvent) {
-	global.addEventListener('onstorage', sessionListener);
+	global.attachEvent('onstorage', sessionListener);
 }
 
 module.exports._clock = clock;


### PR DESCRIPTION
I was randomly looking at this file and noticed this. Not sure if this is a problem (do we support really old versions of IE?) but the fix seemed easy so I made this PR.