### PR TITLE
Pull out direct access to framed and local

### DIFF
--- a/framed.js
+++ b/framed.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./src/framed');

--- a/local.js
+++ b/local.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./src/local');

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/Brightspace/frau-jwt/issues"
   },
   "dependencies": {
-    "frau-framed": "^1.0.0",
+    "frau-framed": "^1.0.1",
     "frau-superagent-xsrf-token": "^1.0.1",
     "ifrau": "^0.13.1",
     "lie": "^3.0.2",


### PR DESCRIPTION
Useful for being able to browserify the whole thing without browserifying a bunch of stuff we don't actually need.