### PR TITLE
Update superagent to 3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,10 @@
   },
   "dependencies": {
     "frau-framed": "^1.0.1",
-    "frau-superagent-xsrf-token": "^1.0.1",
+    "frau-superagent-xsrf-token": "^2.0.0",
     "ifrau": "^0.13.1",
     "lie": "^3.0.2",
-    "superagent": "^1.8.3"
+    "superagent": "^3.4.1"
   },
   "devDependencies": {
     "browserify": "^13.0.0",
@@ -56,7 +56,7 @@
     "frau-publisher": "^2.5.3",
     "istanbul": "^0.4.3",
     "mocha": "^2.4.5",
-    "nock": "^8.0.0",
+    "nock": "^9.0.4",
     "peanut-gallery": "^1.1.1",
     "rimraf": "^2.5.2",
     "sinon": "^1.17.3",

--- a/test/local.spec.js
+++ b/test/local.spec.js
@@ -21,7 +21,7 @@ describe('local', function() {
 
 	it('should default to scope *:*:*', function() {
 		var req = nock('http://localhost')
-			.post(TOKEN_ROUTE, /scope=\*%3A\*%3A\*/)
+			.post(TOKEN_ROUTE, /scope=%2A%3A%2A%3A%2A/)
 			.reply(200, {
 				expires_at: 1,
 				access_token: 'foo-bar-baz'


### PR DESCRIPTION
Not sure about this one as updating caused a test to break:

```
  local
    1) should default to scope *:*:*
    ✓ should resolve with token the LMS returns
    ✓ should dedupe concurrent requests for the same scope
    ✓ should not dedupe concurrent requests for different scopes
    ✓ should cache tokens per scope
    ✓ should re-fetch tokens after expiry
    ✓ should account for clock skew from server when determining expiry


  6 passing (68ms)
  1 failing

  1) local should default to scope *:*:*:
     Error: Nock: No match for request {
  "method": "POST",
  "url": "http://localhost/d2l/lp/auth/oauth2/token",
  "body": "scope=%2A%3A%2A%3A%2A"
}
      at end (node_modules/nock/lib/request_overrider.js:260:17)
      at OverriddenClientRequest.RequestOverrider.req.end (node_modules/nock/lib/request_overrider.js:160:7)
      at Request._end (node_modules/superagent/lib/node/index.js:944:9)
      at Request.end (node_modules/superagent/lib/node/index.js:745:15)
      at Timeout.completeRequest [as _onTimeout] (node_modules/frau-superagent-xsrf-token/src/index.js:21:15)
```

First I tried updating nock, didn't help (I left that change in anyhow). Then I made the change to the spec, which caused the test to pass. Although I don't understand the test to begin with