### PR TITLE
deps: update browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "superagent": "^3.4.1"
   },
   "devDependencies": {
-    "browserify": "^13.0.0",
+    "browserify": "^14.3.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "coveralls": "^2.11.9",


### PR DESCRIPTION
Split out separately because newer Browserify uses a different Buffer which drops support for IE8-10, which would be fine, but also, at least given the set of code we're bundling, we don't bring in Buffer.

Bundle ends up being the same.