### PR TITLE
build: bundle host as part of build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: node_js
 node_js:
 - 6
 sudo: false
+script:
+- npm test
+- npm run bundle-host
 after_success:
 - npm run report-coverage
 - '[ "$TRAVIS_SECURE_ENV_VARS" = "true" ] && [ "x$TRAVIS_TAG" != "x" ] && npm run publish:cdn'


### PR DESCRIPTION
previously, it jsut being in after-success meant everything was green and you didn't really notice.
now, a failure in the bundle will fail the build, although it's now done twice