### PR TITLE
outputting a de-UMD global bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frau-jwt",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Utility to get a JWT from a FRA",
   "main": "index.js",
   "scripts": {
@@ -9,7 +9,7 @@
     "test": "npm run check-style && npm run test-unit",
     "report-coverage": "coveralls < coverage/lcov.info",
     "prebundle-host": "rimraf dist && mkdir dist",
-    "bundle-host": "browserify -g uglifyify -s frau-jwt/host host.js > dist/host.js",
+    "bundle-host": "browserify -g uglifyify -s frau-jwt/host host.js > dist/host.js && browserify -g uglifyify -p deumdify -s frau-jwt/host host.js > dist/host-global.js",
     "prepublish:cdn": "npm run bundle-host",
     "publish:cdn": "frau-publisher | peanut-gallery"
   },
@@ -47,6 +47,7 @@
     "chai": "^3.5.0",
     "chai-as-promised": "^6.0.0",
     "coveralls": "^2.11.9",
+    "deumdify": "^1",
     "eslint": "^3.19.0",
     "eslint-config-brightspace": "^0.2.0",
     "frau-publisher": "^2.7.12",


### PR DESCRIPTION
**Background**

Starting with `20.20.8` and the unbundled BSI builds, I stopped using SystemJS to load the `ifrau` host and `frau-jwt` bundles for iFRAs. Instead, I just loaded them as scripts and referenced the global variables that they defined.

This was done to avoid conflicts with how the BSI tooling also uses a different version of SystemJS for legacy-Edge -- having 2 versions of SystemJS on the page obviously caused issues.

**Problem**

An unintended side effect of that change was that the `ifrau` host and `frau-jwt` bundles are browserify bundles, which means they include AMD/UMD wrappers. On their own that's fine, but as soon as they're included on the same page as a UMD FRA... 💣 ! The UMD FRA includes `Require.js` which then sees the AMD/UMD wrappers in these includes and explodes.

**Solution**

We've done this before whenever the UMD time bomb goes off -- use the `deumdify` plugin to strip out the AMD/UMD definitions, resulting in just a global variable. I'll be making the same change to `ifrau` host.