### PR TITLE
upgrading to latest. node to fix build issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
-node_js:
-  - 6
-sudo: false
+node_js: node
 script:
   - npm test
   - npm run bundle-host

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frau-jwt",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Utility to get a JWT from a FRA",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The release failed to publish because one of the dependencies required at least Node > 8. 