### PR TITLE
DE48078: LX > Sessions don't expire after timeout limit - Longer than 50 minute sessions

### DIFF
--- a/local.js
+++ b/local.js
@@ -72,7 +72,8 @@ function requestToken(scope) {
 			.post(TOKEN_ROUTE)
 			.type('form')
 			.send({
-				scope: scope
+				scope: scope,
+				'X-D2L-Session': 'no-keep-alive'
 			})
 			.use(xsrfToken)
 			.end(function(err, res) {


### PR DESCRIPTION
Add parameter to token fetch payload to not keep session alive

Rally Link:
[DE48078: LX > Sessions don't expire after timeout limit - Longer than 50 minute sessions](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F631243645551)