### PR TITLE
DE48078: LX > Sessions don't expire after timeout limit - Longer than 50 minute sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frau-jwt",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Utility to get a JWT from a FRA",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add optional parameter 'keepSessionAliveOnRefetch' that determines whether to add 'X-D2L-Session': 'no-keep-alive' to the payload for token refetching.

Rally Link: [DE48078](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F631243645551)