### PR TITLE
fix: upgrade to ifrau 0.40

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "frau-framed": "^1",
     "frau-xsrf-token": "^3",
-    "ifrau": "^0.39"
+    "ifrau": "^0.40"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7",


### PR DESCRIPTION
Version `0.40` of `ifrau` was recently released, which is triggering a bunch of Dependabot upgrades. It's a "major" release though, so we need to make it across all BSI things (core, `frau-jwt`, `hmc-users` and BSI itself).