### PR TITLE
GAUD-9545: fix version

### DIFF
--- a/local.js
+++ b/local.js
@@ -129,7 +129,7 @@ module.exports = function getLocalJwt(scope, opts) {
 		});
 };
 
-window.addEventListener && window.addEventListener('storage', function sessionListener(e) {
+global.addEventListener && global.addEventListener('storage', function sessionListener(e) {
 	switch (e.key) {
 		case 'Session.Expired':
 		case 'Session.UserId':

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "check-style": "eslint .",
-    "test-unit": "mocha -r jsdom-global/register test/*.spec.js",
+    "test-unit": "mocha test/*.spec.js",
     "test": "npm run check-style && npm run test-unit",
     "prebundle-host": "rimraf dist && mkdir dist",
     "bundle-host": "browserify -g uglifyify -s frau-jwt/host host.js > dist/host.js && browserify -g uglifyify -p deumdify -s frau-jwt/host host.js > dist/host-global.js",
@@ -52,7 +52,6 @@
     "eslint": "^7",
     "eslint-config-brightspace": "^0.2.0",
     "frau-publisher": "^2.7.12",
-    "jsdom-global": "^3",
     "mocha": "^11",
     "nock": "^14",
     "rimraf": "^2.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frau-jwt",
-  "version": "2.3.1",
+  "version": "2.3.0",
   "description": "Utility to get a JWT from a FRA",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Version `2.3.1` never actually released to npm, which is now preventing a new release on top of it from being created. This resets the version back to `2.3.0` to match what's currently on npm. I've deleted the GitHub release & tag for `2.3.1` as well.