### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "bugs": {
     "url": "https://github.com/Brightspace/frau-jwt/issues"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "dependencies": {
     "frau-xsrf-token": "^3",
     "ifrau": "^0.42"


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564